### PR TITLE
Emergency Modification: Build trouble caused by CMakeLists.txt

### DIFF
--- a/hello_world/CMakeLists.txt
+++ b/hello_world/CMakeLists.txt
@@ -1,1 +1,36 @@
-/opt/ros/noetic/share/catkin/cmake/toplevel.cmake
+cmake_minimum_required(VERSION 3.0.2)
+project(hello_world)
+
+## Compile as C++11, supported in ROS Kinetic and newer
+# add_compile_options(-std=c++11)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  rospy
+  std_msgs
+)
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if your package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+  # None
+)
+
+###########
+## Build ##
+###########
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(
+# include
+  ${catkin_INCLUDE_DIRS}
+)


### PR DESCRIPTION
## Abstruct
CMakeLists.txtが何らかの原因でシンボリックリンク化されてremoteに上がってたので緊急修復です

## Discription
特になし

